### PR TITLE
Fixed compiler errors in AnnotationMarshaller.groovy

### DIFF
--- a/src/groovy/grails/plugins/jsonapis/AnnotationMarshaller.groovy
+++ b/src/groovy/grails/plugins/jsonapis/AnnotationMarshaller.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Log
 
 import org.codehaus.groovy.grails.commons.DefaultGrailsDomainClass
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty
+import org.codehaus.groovy.grails.web.converters.Converter
 import org.codehaus.groovy.grails.web.converters.marshaller.ObjectMarshaller
 
 /**
@@ -13,7 +14,7 @@ import org.codehaus.groovy.grails.web.converters.marshaller.ObjectMarshaller
  * It also contains static helper methods to help with reflection.
  */
 @Log
-class AnnotationMarshaller<T> implements ObjectMarshaller<T> {
+class AnnotationMarshaller<T extends Converter> implements ObjectMarshaller<T> {
 	protected final DefaultGrailsDomainClass forClass
 	protected final List<GrailsDomainClassProperty> propertiesToSerialize
 
@@ -29,7 +30,6 @@ class AnnotationMarshaller<T> implements ObjectMarshaller<T> {
 				declaredNamespaces?.each { apiNamespace -> namespaces << apiNamespace }
 			}
 		}
-		log.info "Found following JSON namespaces: ${namespaces.join(', ')}"
 		return namespaces
 	}
 


### PR DESCRIPTION
line 17 had an invalid generic declaration
line 33 referenced the injected member variable log from a static
context which is illegal, so this line was removed
